### PR TITLE
increase composability

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -94,19 +94,20 @@ in rec {
       string_aux_list = map (onPath readFile) (lib.toList aux);
     in concatStringsSep "\n" string_aux_list;
 
+  gitignoreFilterPure = filter: ign: root: name: type:
+    gitignoreFilter (gitignoreCompileIgnore ign root) root name type
+    && filter name type;
+
+  withGitignoreFile = aux: root:
+    lib.toList aux ++ [(root + "/.gitignore")];
+
   # filterSource derivatives
 
   gitignoreFilterSourcePure = filter: ign: root:
-    filterSource
-      (name: type:
-        gitignoreFilter (gitignoreCompileIgnore ign root) root name type
-        &&
-        filter name type
-      ) root;
+    filterSource (gitignoreFilterPure filter ign root) root;
 
   gitignoreFilterSourceAux = filter: aux: root:
-    let aux' = lib.toList aux ++ [(root + "/.gitignore")];
-    in gitignoreFilterSourcePure filter aux' root;
+    gitignoreFilterSourcePure filter (withGitignoreFile aux root) root;
 
   gitignoreFilterSource = filter: gitignoreFilterSourceAux filter "";
 


### PR DESCRIPTION
This would make it possible to write e.g.

```nix
constGitIgnore = pathname: root: aux:
  builtins.path {
    name    = pathname;
    path    = root;
    filter  = name: type:
      let aux' = ...; in
      gitignoreFilter (gitignoreCompileIgnore aux' root) root name type
      && lib.cleanSourceFilter name type;
  };
```
as:

```nix
constGitIgnore = pathname: root: aux:
  builtins.path {
    name    = pathname;
    path    = root;
    filter  = gitignoreFilterPure lib.cleanSourceFilter (withGitignoreFile aux root) root;
  };
```

\- Felix