### PR TITLE
Fix gitignoreRecursiveSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ If you wish to use a filter that would search for `.gitignore` files in subdirec
 just like git does by default, use this function.
 
     gitignoreFilterRecursiveSource = filter: patterns: root:
-    gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+    gitignoreRecursiveSource = gitignoreFilterRecursiveSource (_: _: true);
+
 
 ## Testing
 

--- a/default.nix
+++ b/default.nix
@@ -172,5 +172,5 @@ in rec {
       "use [] or \"\" if there are no additional patterns"
     else gitignoreFilterSource (_: _: true) patterns;
 
-  gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+  gitignoreRecursiveSource = gitignoreFilterRecursiveSource (_: _: true);
 }


### PR DESCRIPTION
This seems to better fit the pattern of the other functions and produces the results I expect from the README:
> If you wish to use a filter that would search for `.gitignore` files in subdirectories,
just like git does by default, use this function.
