### PR TITLE
Add name to path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -152,9 +152,14 @@ in rec {
     lib.toList patterns ++ [(compileRecursiveGitignore root)];
 
   # filterSource derivatives
+  gitignoreFilterSourcePureNamed = name: filter: patterns: root:
+    builtins.path {
+      inherit name;
+      path = root;
+      filter = gitignoreFilterPure filter patterns root;
+    };
 
-  gitignoreFilterSourcePure = filter: patterns: root:
-    filterSource (gitignoreFilterPure filter patterns root) root;
+  gitignoreFilterSourcePure = gitignoreFilterSourcePureNamed "gitignore-src";
 
   gitignoreFilterSource = filter: patterns: root:
     gitignoreFilterSourcePure filter (withGitIgnoredFilesAndDirs patterns root) root;


### PR DESCRIPTION
I added this for personal use, since I need the path to be named. Without the path having a name I get a nix cache miss simply because the parent directory has a different name. Jenkins for example uses the branch name when in makes a work-space, resulting in a cache nearly miss every time.

I am not sure this is the right approach for merging however. I am not sure how you would want this functionality added to the project, or what you think would make a good API for this. Sending the PR to start the discussion. 